### PR TITLE
Remove multiple urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ Currently implemented issuers:
 Create an issuer:
 ```go
 issuer := &certbot.VaultIssuer{
-    VaultURLs: []*url.URL{
-        &url.URL{
-            Scheme: "https",
-            Host: "my-local-vault-instance.com"
-        },
+    VaultURL: &url.URL{
+        Scheme: "https",
+        Host: "my-local-vault-instance.com"
     },
     Token:     "myVaultToken",
     Role:      "myVaultRole",

--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/johanbrandhorst/certbot)](https://goreportcard.com/report/github.com/johanbrandhorst/certbot)
 
 Certbot allows easy automatic certificate distribution and maintenance.
-It exposes an `Issuer` interface which is used to allow switching
-between issuer backends.
+Certificates are requested as TLS connectoins
+are made, courtesy of the `GetCertificate` and `GetClientCertificate`
+`tls.Config` hooks. Certificates are optionally cached.
 
 ## Issuers
 
+Certbot exposes an `Issuer` interface which is used to allow switching
+between issuer backends.
+
 Currently implemented issuers:
 
-1. Vault PKI Secret Engine
+- Vault PKI Secrets Engine
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Certbot
+[![GoDoc](https://godoc.org/github.com/johanbrandhorst/certbot?status.svg)](https://godoc.org/github.com/johanbrandhorst/certbot)
+[![Go Report Card](https://goreportcard.com/badge/github.com/johanbrandhorst/certbot)](https://goreportcard.com/report/github.com/johanbrandhorst/certbot)
 
 Certbot allows easy automatic certificate distribution and maintenance.
 It exposes an `Issuer` interface which is used to allow switching

--- a/certbot_test.go
+++ b/certbot_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 	"net"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -31,9 +30,9 @@ var _ = Describe("Certbot", func() {
 			cp := x509.NewCertPool()
 			Expect(cp.AppendCertsFromPEM(httpCertPEM)).To(BeTrue())
 			iss := &certbot.VaultIssuer{
-				VaultURLs: []*url.URL{vaultURL},
-				Token:     rootToken,
-				Role:      testRole,
+				VaultURL: vaultURL,
+				Token:    rootToken,
+				Role:     testRole,
 				TLSConfig: &tls.Config{
 					RootCAs: cp,
 				},
@@ -248,9 +247,9 @@ var _ = Describe("gRPC Test", func() {
 				cb = &certbot.Certbot{
 					CommonName: "Certbot",
 					Issuer: &certbot.VaultIssuer{
-						VaultURLs: []*url.URL{vaultURL},
-						Token:     rootToken,
-						Role:      testRole,
+						VaultURL: vaultURL,
+						Token:    rootToken,
+						Role:     testRole,
 						TLSConfig: &tls.Config{
 							RootCAs: cp,
 						},


### PR DESCRIPTION
This will probably rarely be used, and I think managing extra Vault instances should be the responsbility of the layer above this.

Also remove the auto-reconnection as I think that probably shouldn't be handled by a library like this.